### PR TITLE
Add Dockerfile and instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,37 @@ Si vous modifiez des règles de consensus, vous n'appartiendrez plus au même r�
 - Mettre de meilleurs [images](https://github.com/Crypto-lyon/INSAcoin/tree/master/src/qt/res/images) que celles que je vais mettre
 - ...
 
+Setup INSAcoin in a Docker container
+------
+
+### Building and running INSAcoin docker image
+
+Run the following commands to compile INSAcoin in Docker and build the image :
+
+```shell
+cd contrib/docker
+docker build --rm -t insacoin .
+```
+
+Launch INSAcoin daemon :
+
+```
+docker run -d -v ~/.insacoin:/root/.insacoin --name insacoin insacoin
+```
+
+Using insacoin-cli :
+
+```
+docker exec -it insacoin insacoin-cli getinfo
+```
+
+### Running INSAcoin UI
+
+```
+xhost +local:docker && docker run -ti --rm --name insacoin -e DISPLAY=$DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix -v ~/.insacoin:/root/.insacoin insacoin insacoin-qt
+```
+
+
 License
 -------
 

--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -1,0 +1,48 @@
+FROM debian:9
+
+ENV INSACOIN_VERSION=0.10
+
+RUN apt update && \
+	apt install -y --no-install-recommends \
+	libboost-all-dev \
+	miniupnpc build-essential \
+	libtool \
+	autotools-dev \
+	automake \
+	pkg-config \
+	libevent-dev \
+	bsdmainutils \
+	python3 \
+	software-properties-common \
+	libminiupnpc-dev \
+	libzmq3-dev \
+	libqt5gui5 \
+	libqt5core5a \
+	libqt5dbus5 \
+	qttools5-dev \
+	qttools5-dev-tools \
+	libprotobuf-dev \
+	protobuf-compiler \
+	wget \
+	git \
+	qt5-default \
+	libssl1.0-dev
+
+RUN git clone -b ${INSACOIN_VERSION} https://github.com/Crypto-lyon/INSAcoin /opt/INSAcoin
+
+RUN chmod +x /opt/INSAcoin/scripts/install_libdb4.8.sh && \
+	/opt/INSAcoin/scripts/install_libdb4.8.sh amd64
+
+WORKDIR /opt/INSAcoin/
+
+RUN ./autogen.sh && \
+	./configure && \ 
+	make -j 4 && \
+	make install
+
+RUN apt-get purge -y --auto-remove ca-certificates build-essential libtool autotools-dev automake pkg-config bsdmainutils wget git
+
+#CMD ["insacoin-qt"]
+CMD ["insacoind","-txindex","-reindex"]
+
+


### PR DESCRIPTION
Voici une image docker pour INSAcoin.

Le build de l'image effectue la compilation du projet, ce qui peut être un peu long.

Il est possible de lancer l'interface graphique insacoin-qt depuis le container avec un système host qui a un serveur X.